### PR TITLE
Bump app-data-browser-next to master

### DIFF
--- a/apps/app-data-browser-next/deployment.yaml
+++ b/apps/app-data-browser-next/deployment.yaml
@@ -17,7 +17,7 @@ spec:
         require-auth0: disabled
     spec:
       containers:
-      - image: registry.gitlab.com/dataware-tools/app-data-browser-next:develop
+      - image: registry.gitlab.com/dataware-tools/app-data-browser-next:master
         name: app
         ports:
           - containerPort: 3000


### PR DESCRIPTION
## What?
app-data-browser-next を master に更新

## Why?
develop ブランチ廃止のため