### PR TITLE
Bump api-meta-store to v0.3.0

### DIFF
--- a/apps/api-meta-store/deployment.yaml
+++ b/apps/api-meta-store/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         require-auth0: enabled
     spec:
       containers:
-      - image: registry.gitlab.com/dataware-tools/api-meta-store:v0.2.1
+      - image: registry.gitlab.com/dataware-tools/api-meta-store:v0.3.0
         name: app
         ports:
           - containerPort: 8080


### PR DESCRIPTION
## What?
api-meta-store を v0.3.0 に更新

## Why?
機能追加のため