### PR TITLE
Bump app-launcher to v0.2.0

### DIFF
--- a/apps/app-launcher/deployment.yaml
+++ b/apps/app-launcher/deployment.yaml
@@ -17,7 +17,7 @@ spec:
         require-auth0: disabled
     spec:
       containers:
-      - image: registry.gitlab.com/dataware-tools/app-launcher:v0.2.0.alpha
+      - image: registry.gitlab.com/dataware-tools/app-launcher:v0.2.0
         name: app
         ports:
           - containerPort: 3000


### PR DESCRIPTION
## What?
Bump `app-launcher` from v0.2.0.alpha to v0.2.0

## Why?
To use the latest app