### PR TITLE
Add `require-auth0-user-admin`

### DIFF
--- a/apps/api-permission-manager/deployment.yaml
+++ b/apps/api-permission-manager/deployment.yaml
@@ -17,6 +17,7 @@ spec:
         app: api-permission-manager
         version: v1
         require-auth0: enabled
+        require-auth0-user-admin: enabled
     spec:
       containers:
       - image: registry.gitlab.com/dataware-tools/api-permission-manager:master

--- a/common/security/authorization-policy.yaml
+++ b/common/security/authorization-policy.yaml
@@ -53,3 +53,18 @@ spec:
     - to:
         - operation:
             paths: ["*"]
+---
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: require-auth0-user-admin
+spec:
+  action: DENY
+  selector:
+    matchLabels:
+      require-auth0-user-admin: enabled
+  rules:
+    - when:
+        - key: request.auth.claims[permissions]
+          notValues:
+            - "admin:user"


### PR DESCRIPTION
## What?
Add an authorization-policy `require-auth0-user-admin`

## Why?
To restrict users who can access `api-permission-manager`