### PR TITLE
Bump api-meta-store to `v0.3.2`

### DIFF
--- a/apps/api-meta-store/deployment.yaml
+++ b/apps/api-meta-store/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         require-auth0: enabled
     spec:
       containers:
-      - image: registry.gitlab.com/dataware-tools/api-meta-store:v0.3.1
+      - image: registry.gitlab.com/dataware-tools/api-meta-store:v0.3.2
         name: app
         ports:
           - containerPort: 8080


### PR DESCRIPTION
## What?
Bump api-meta-store from `v0.3.1` to `v0.3.2`

## Why?
It includes bug fixes