### PR TITLE
Bump api-meta-store to `v0.4.3`

### DIFF
--- a/apps/api-meta-store/deployment.yaml
+++ b/apps/api-meta-store/deployment.yaml
@@ -28,6 +28,8 @@ spec:
             value: "8080"
           - name: SECRET_KEY
             value: "api-meta-store"
+          - name: PERMISSION_MANAGER_SERVICE
+            value: "https://demo.dataware-tools.com/api/latest/permission_manager"
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/apps/api-meta-store/deployment.yaml
+++ b/apps/api-meta-store/deployment.yaml
@@ -29,7 +29,7 @@ spec:
           - name: SECRET_KEY
             value: "api-meta-store"
           - name: PERMISSION_MANAGER_SERVICE
-            value: "https://demo.dataware-tools.com/api/latest/permission_manager"
+            value: "https://api-permission-manager:8080"
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/apps/api-meta-store/deployment.yaml
+++ b/apps/api-meta-store/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         require-auth0: enabled
     spec:
       containers:
-      - image: registry.gitlab.com/dataware-tools/api-meta-store:v0.4.1
+      - image: registry.gitlab.com/dataware-tools/api-meta-store:v0.4.2
         name: app
         ports:
           - containerPort: 8080

--- a/apps/api-meta-store/deployment.yaml
+++ b/apps/api-meta-store/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         require-auth0: enabled
     spec:
       containers:
-      - image: registry.gitlab.com/dataware-tools/api-meta-store:v0.4.2
+      - image: registry.gitlab.com/dataware-tools/api-meta-store:v0.4.3
         name: app
         ports:
           - containerPort: 8080

--- a/apps/api-meta-store/deployment.yaml
+++ b/apps/api-meta-store/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         require-auth0: enabled
     spec:
       containers:
-      - image: registry.gitlab.com/dataware-tools/api-meta-store:v0.4.0
+      - image: registry.gitlab.com/dataware-tools/api-meta-store:v0.4.1
         name: app
         ports:
           - containerPort: 8080

--- a/apps/api-meta-store/deployment.yaml
+++ b/apps/api-meta-store/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         require-auth0: enabled
     spec:
       containers:
-      - image: registry.gitlab.com/dataware-tools/api-meta-store:v0.3.2
+      - image: registry.gitlab.com/dataware-tools/api-meta-store:v0.4.0
         name: app
         ports:
           - containerPort: 8080

--- a/apps/api-meta-store/deployment.yaml
+++ b/apps/api-meta-store/deployment.yaml
@@ -29,7 +29,7 @@ spec:
           - name: SECRET_KEY
             value: "api-meta-store"
           - name: PERMISSION_MANAGER_SERVICE
-            value: "https://api-permission-manager:8080"
+            value: "http://api-permission-manager:8080"
         imagePullPolicy: Always
         livenessProbe:
           httpGet:


### PR DESCRIPTION
## What?
Bump api-meta-store to `v0.4.3`

## Why?
To reflect the updates