### PR TITLE
Fix the bug that users without permission `admin:user` fails to get metadata

### DIFF
--- a/common/security/authorization-policy.yaml
+++ b/common/security/authorization-policy.yaml
@@ -64,7 +64,10 @@ spec:
     matchLabels:
       require-auth0-user-admin: enabled
   rules:
-    - when:
+    - to:
+        - operation:
+            methods: [ "POST", "PUT", "PATCH", "DELETE" ]
+      when:
         - key: request.auth.claims[permissions]
           notValues:
             - "admin:user"


### PR DESCRIPTION
## What?
Resolve https://github.com/dataware-tools/dataware-tools/issues/3
Resolve https://github.com/dataware-tools/dataware-tools/issues/35

Fix the bug that users who do not have permission `admin:user` 
fails to get metadata from `api-meta-store`.  
Below is the reason why it failed.
1. Users request metadata to `api-meta-store`
2. `api-meta-store` verifies user permissions by requesting to `api-permission-manager` with the users' JWT
3. The request fails if permission `admin:user` is not included in JWT as `GET` method is not allowed without the permission (This configuration was declared in AuthorizationPolicy `require-auth0-user-admin`)

## Why?
Bug fix