### PR TITLE
Bump api-meta-store to `v0.4.5`

### DIFF
--- a/apps/api-meta-store/deployment.yaml
+++ b/apps/api-meta-store/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         require-auth0: enabled
     spec:
       containers:
-      - image: registry.gitlab.com/dataware-tools/api-meta-store:v0.4.3
+      - image: registry.gitlab.com/dataware-tools/api-meta-store:v0.4.4
         name: app
         ports:
           - containerPort: 8080

--- a/apps/api-meta-store/deployment.yaml
+++ b/apps/api-meta-store/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         require-auth0: enabled
     spec:
       containers:
-      - image: registry.gitlab.com/dataware-tools/api-meta-store:v0.4.4
+      - image: registry.gitlab.com/dataware-tools/api-meta-store:v0.4.5
         name: app
         ports:
           - containerPort: 8080

--- a/apps/api-permission-manager/deployment.yaml
+++ b/apps/api-permission-manager/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         require-auth0-user-admin: enabled
     spec:
       containers:
-      - image: registry.gitlab.com/dataware-tools/api-permission-manager:v0.1.0
+      - image: registry.gitlab.com/dataware-tools/api-permission-manager:v0.1.1
         name: app
         ports:
           - containerPort: 8080


### PR DESCRIPTION
## What?
Bump api-meta-store to `v0.4.4`

## Why?
It includes bug fixes