### PR TITLE
Add authorization policy `require-auth0-job-admin`

### DIFF
--- a/apps/api-job-store/deployment.yaml
+++ b/apps/api-job-store/deployment.yaml
@@ -17,6 +17,7 @@ spec:
         app: api-job-store
         version: v1
         require-auth0: enabled
+        require-auth0-job-admin: enabled
     spec:
       containers:
       - image: registry.gitlab.com/dataware-tools/api-job-store:v1.0

--- a/common/security/authorization-policy.yaml
+++ b/common/security/authorization-policy.yaml
@@ -71,3 +71,23 @@ spec:
         - key: request.auth.claims[permissions]
           notValues:
             - "admin:user"
+---
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: require-auth0-job-admin
+spec:
+  action: DENY
+  selector:
+    matchLabels:
+      require-auth0-job-admin: enabled
+  rules:
+    - to:
+        - operation:
+            methods: [ "POST", "PUT", "PATCH", "DELETE" ]
+            paths:
+              - "/job_templates*"
+      when:
+        - key: request.auth.claims[permissions]
+          notValues:
+            - "admin:job"


### PR DESCRIPTION
## What?
Add authorization policy `require-auth0-job-admin`

## Why?
To restrict the use of `api-job-store`