### PR TITLE
Bump APIs and APPs

### DIFF
--- a/apps/api-file-provider/deployment-public.yaml
+++ b/apps/api-file-provider/deployment-public.yaml
@@ -22,7 +22,7 @@ spec:
         require-auth0: disabled
     spec:
       containers:
-      - image: registry.gitlab.com/dataware-tools/api-file-provider:v1.3
+      - image: registry.gitlab.com/dataware-tools/api-file-provider:v1.4
         name: app
         ports:
           - containerPort: 8080

--- a/apps/api-file-provider/deployment.yaml
+++ b/apps/api-file-provider/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         require-auth0: enabled
     spec:
       containers:
-      - image: registry.gitlab.com/dataware-tools/api-file-provider:v1.3
+      - image: registry.gitlab.com/dataware-tools/api-file-provider:v1.4
         name: app
         ports:
           - containerPort: 8080

--- a/apps/api-job-store/deployment.yaml
+++ b/apps/api-job-store/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         require-auth0-job-admin: enabled
     spec:
       containers:
-      - image: registry.gitlab.com/dataware-tools/api-job-store:v1.0
+      - image: registry.gitlab.com/dataware-tools/api-job-store:v1.1
         name: app
         ports:
           - containerPort: 8080

--- a/apps/api-meta-store/deployment.yaml
+++ b/apps/api-meta-store/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         require-auth0: enabled
     spec:
       containers:
-        - image: registry.gitlab.com/dataware-tools/api-meta-store:v0.4.7
+        - image: registry.gitlab.com/dataware-tools/api-meta-store:v0.4.8
           name: app
           ports:
             - containerPort: 8080

--- a/apps/api-permission-manager/deployment.yaml
+++ b/apps/api-permission-manager/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         require-auth0-user-admin: enabled
     spec:
       containers:
-      - image: registry.gitlab.com/dataware-tools/api-permission-manager:v0.1.1
+      - image: registry.gitlab.com/dataware-tools/api-permission-manager:v0.1.2
         name: app
         ports:
           - containerPort: 8080

--- a/apps/app-data-browser-next/deployment.yaml
+++ b/apps/app-data-browser-next/deployment.yaml
@@ -18,7 +18,7 @@ spec:
         require-auth0: disabled
     spec:
       containers:
-      - image: registry.gitlab.com/dataware-tools/app-data-browser-next:v0.0.3
+      - image: registry.gitlab.com/dataware-tools/app-data-browser-next:v0.0.6
         name: app
         ports:
           - containerPort: 3000


### PR DESCRIPTION
## What?
Bump the following APIs and APPs:
- `api-file-provider`: `v1.3` -> `v1.4`
- `api-job-store`: `v1.0` -> `v1.1`
- `api-meta-store`: `v0.4.7` -> `v0.4.8`
- `api-permission-manager`: `v0.1.1` -> `v0.1.2`
- `app-data-browser-next`: `v0.0.3` -> `v0.0.6`

## Why?
To update APIs and APPs