### PR TITLE
Bump apps to release v0.2.2

### DIFF
--- a/apps/app-data-browser-next/deployment.yaml
+++ b/apps/app-data-browser-next/deployment.yaml
@@ -18,7 +18,7 @@ spec:
         require-auth0: disabled
     spec:
       containers:
-      - image: registry.gitlab.com/dataware-tools/app-data-browser-next:v0.0.8
+      - image: registry.gitlab.com/dataware-tools/app-data-browser-next:v0.0.9
         name: app
         ports:
           - containerPort: 3000

--- a/apps/app-user-manager/deployment.yaml
+++ b/apps/app-user-manager/deployment.yaml
@@ -18,7 +18,7 @@ spec:
         require-auth0: disabled
     spec:
       containers:
-      - image: registry.gitlab.com/dataware-tools/app-user-manager:v0.1.5
+      - image: registry.gitlab.com/dataware-tools/app-user-manager:v0.1.6
         name: app
         ports:
           - containerPort: 3000


### PR DESCRIPTION
## What?
Bump the following apps:
- `app-data-browser-next` (v0.0.9)
- `app-user-manager` (v0.1.6)

## Why?
To release v0.2.2