### PR TITLE
Support previewing rosbag files without rosbridge

### DIFF
--- a/apps/api-file-provider/deployment-public.yaml
+++ b/apps/api-file-provider/deployment-public.yaml
@@ -22,7 +22,7 @@ spec:
         require-auth0: disabled
     spec:
       containers:
-      - image: registry.gitlab.com/dataware-tools/api-file-provider:v1.6.2
+      - image: registry.gitlab.com/dataware-tools/api-file-provider:v1.7.0
         name: app
         ports:
           - containerPort: 8080

--- a/apps/api-file-provider/deployment.yaml
+++ b/apps/api-file-provider/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         require-auth0: enabled
     spec:
       containers:
-      - image: registry.gitlab.com/dataware-tools/api-file-provider:v1.6.2
+      - image: registry.gitlab.com/dataware-tools/api-file-provider:v1.7.0
         name: app
         ports:
           - containerPort: 8080

--- a/apps/api-file-provider/virtual-services.yaml
+++ b/apps/api-file-provider/virtual-services.yaml
@@ -17,6 +17,28 @@ spec:
       route:
         - destination:
             host: api-file-provider-public
+      corsPolicy:
+        allowHeaders:
+          - Authorization
+          - Content-Type
+          - Content-Length
+          - Content-Range
+          - Accept-Ranges
+          - ETag
+          - Range
+        allowMethods:
+          - GET
+          - HEAD
+          - OPTIONS
+        allowOrigins:
+          - exact: 'https://webviz.io'
+          - exact: 'https://webviz.hdwlab.com'
+        exposeHeaders:
+          - Authorization
+          - Content-Type
+          - Content-Length
+          - Accept-Ranges
+          - ETag
     - name: api-file-provider
       match:
         - uri:

--- a/apps/app-data-browser-next/deployment.yaml
+++ b/apps/app-data-browser-next/deployment.yaml
@@ -18,7 +18,7 @@ spec:
         require-auth0: disabled
     spec:
       containers:
-      - image: registry.gitlab.com/dataware-tools/app-data-browser-next:v0.0.10
+      - image: registry.gitlab.com/dataware-tools/app-data-browser-next:v0.0.11
         name: app
         ports:
           - containerPort: 3000


### PR DESCRIPTION
## What?
Bump the following Apps and APIs
- api-file-provider
- app-data-browser-next

## Why?
Tp support previewing rosbag files without rosbridge