### PR TITLE
Bump APIs and APPs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,11 @@ You can deploy an example version of Dataware-tools using files under `distribut
 kustomize build distributions/demo | kubectl apply -f-
 
 ```
+
+
+## Developers' guide
+You can find which component to update with the following command:  
+```bash
+$ ./utils/list_update_candidates.sh
+
+```

--- a/apps/api-job-store/deployment.yaml
+++ b/apps/api-job-store/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         require-auth0-job-admin: enabled
     spec:
       containers:
-      - image: registry.gitlab.com/dataware-tools/api-job-store:v1.1
+      - image: registry.gitlab.com/dataware-tools/api-job-store:v1.4.0
         name: app
         ports:
           - containerPort: 8080

--- a/apps/api-job-store/deployment.yaml
+++ b/apps/api-job-store/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   labels:
     app: api-job-store
-    require-db-url: enabled
+    require-pydtk-v4: enabled
   name: api-job-store
 spec:
   replicas: 1

--- a/apps/api-permission-manager/deployment.yaml
+++ b/apps/api-permission-manager/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         require-auth0-user-admin: enabled
     spec:
       containers:
-      - image: registry.gitlab.com/dataware-tools/api-permission-manager:v0.2.1
+      - image: registry.gitlab.com/dataware-tools/api-permission-manager:v0.2.2
         name: app
         ports:
           - containerPort: 8080

--- a/apps/app-data-browser-next/deployment.yaml
+++ b/apps/app-data-browser-next/deployment.yaml
@@ -18,7 +18,7 @@ spec:
         require-auth0: disabled
     spec:
       containers:
-      - image: registry.gitlab.com/dataware-tools/app-data-browser-next:v0.0.11
+      - image: registry.gitlab.com/dataware-tools/app-data-browser-next:v0.1.0
         name: app
         ports:
           - containerPort: 3000

--- a/apps/app-user-manager/deployment.yaml
+++ b/apps/app-user-manager/deployment.yaml
@@ -18,7 +18,7 @@ spec:
         require-auth0: disabled
     spec:
       containers:
-      - image: registry.gitlab.com/dataware-tools/app-user-manager:v0.1.7
+      - image: registry.gitlab.com/dataware-tools/app-user-manager:v0.1.8
         name: app
         ports:
           - containerPort: 3000

--- a/distributions/demo/auth0-client-configs.yaml
+++ b/distributions/demo/auth0-client-configs.yaml
@@ -10,6 +10,14 @@ spec:
       containers:
       - name: app
         env:
+          - name: DATAWARE_TOOLS_AUTH_CONFIG_DOMAIN
+            value: "dataware-tools.us.auth0.com"
+          - name: DATAWARE_TOOLS_AUTH_CONFIG_CLIENT_ID
+            value: "ETb1RhJEbtXlFgWtaHzl5kPCkaYqhTVl"
+          - name: DATAWARE_TOOLS_AUTH_CONFIG_API_URL
+            value: "https://demo.dataware-tools.com/"
+          - name: DATAWARE_TOOLS_AUTH_MANAGE_PAGE
+            value: "https://manage.auth0.com/dashboard/us/dataware-tools/users"
           - name: NEXT_PUBLIC_DATAWARE_TOOLS_AUTH_CONFIG_DOMAIN
             value: "dataware-tools.us.auth0.com"
           - name: NEXT_PUBLIC_DATAWARE_TOOLS_AUTH_CONFIG_CLIENT_ID

--- a/utils/list_update_candidates.sh
+++ b/utils/list_update_candidates.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#
+# List the latest version of components
+#
+# Created by Daiki Hayashi <hayashi.daiki@hdwlab.co.jp>
+#
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+# Color management
+NC='\033[0m'      # No Color
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+
+# Target components
+mapfile components <<EOF
+api-file-provider
+api-meta-store
+api-permission-manager
+app-data-browser-next
+app-launcher
+app-user-manager
+EOF
+
+while read component
+do
+  [[ ! -n "${component}" ]] && continue
+
+  image=$(cat ${SCRIPT_DIR}/../apps/${component}/deployment.yaml | yq read - 'spec.template.spec.containers[0].image')
+  current_tag=${image##*:}
+  latest_tag=$(curl -s https://api.github.com/repos/dataware-tools/${component}/releases/latest | jq -r '.tag_name')
+
+  [[ "${latest_tag}" != "${current_tag}" ]] \
+    && printf "${RED}${component}: ${current_tag} -> ${latest_tag}${NC}\n" \
+    || printf "${GREEN}${component}: Up to date (${latest_tag})${NC}\n"
+
+done <<< ${components[@]}


### PR DESCRIPTION
## What?
- Bump the following components
  - api-job-store: `v1.1` -> `v1.4.0`
  - api-permission-manager: `v0.2.1` -> `v0.2.2`
  - app-data-browser-next: `v0.0.11` -> `v0.1.0`
  - app-user-manager: `v0.1.7` -> `v0.1.8`
- Add a convenient script `utils/list_update_candidates.sh`

## Why?
- To support checking permissions in api-job-store
- To find which component to update easily