### PR TITLE
Bump api-file-provider to v1.7.1

### DIFF
--- a/apps/api-file-provider/deployment-public.yaml
+++ b/apps/api-file-provider/deployment-public.yaml
@@ -22,7 +22,7 @@ spec:
         require-auth0: disabled
     spec:
       containers:
-      - image: registry.gitlab.com/dataware-tools/api-file-provider:v1.7.0
+      - image: registry.gitlab.com/dataware-tools/api-file-provider:v1.7.1
         name: app
         ports:
           - containerPort: 8080

--- a/apps/api-file-provider/deployment.yaml
+++ b/apps/api-file-provider/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         require-auth0: enabled
     spec:
       containers:
-      - image: registry.gitlab.com/dataware-tools/api-file-provider:v1.7.0
+      - image: registry.gitlab.com/dataware-tools/api-file-provider:v1.7.1
         name: app
         ports:
           - containerPort: 8080


### PR DESCRIPTION
## What?
Bump api-file-provider to v1.7.1

## Why?
Bug fix

## See also
https://github.com/dataware-tools/api-file-provider/pull/34