### PR TITLE
Bump api-meta-store to v0.5.2

### DIFF
--- a/apps/api-meta-store/deployment.yaml
+++ b/apps/api-meta-store/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         require-auth0: enabled
     spec:
       containers:
-        - image: registry.gitlab.com/dataware-tools/api-meta-store:v0.5.1
+        - image: registry.gitlab.com/dataware-tools/api-meta-store:v0.5.2
           name: app
           ports:
             - containerPort: 8080


### PR DESCRIPTION
## What?
Bump api-meta-store to v0.5.2

## Why?
- Resolve dataware-tools/dataware-tools#111 
- Resolve dataware-tools/dataware-tools#100