### PR TITLE
Bump api-meta-store and app-data-browser-next

### DIFF
--- a/apps/base/api-meta-store/deployment.yaml
+++ b/apps/base/api-meta-store/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         require-auth0: enabled
     spec:
       containers:
-        - image: registry.gitlab.com/dataware-tools/api-meta-store:v0.5.2
+        - image: registry.gitlab.com/dataware-tools/api-meta-store:v0.5.3
           name: app
           ports:
             - containerPort: 8080

--- a/apps/base/app-data-browser-next/deployment.yaml
+++ b/apps/base/app-data-browser-next/deployment.yaml
@@ -18,7 +18,7 @@ spec:
         require-auth0: disabled
     spec:
       containers:
-      - image: registry.gitlab.com/dataware-tools/app-data-browser-next:v0.1.2
+      - image: registry.gitlab.com/dataware-tools/app-data-browser-next:v0.1.3
         name: app
         ports:
           - containerPort: 3000


### PR DESCRIPTION
## What?
Bump the following components
- api-meta-store v0.5.2 -> v0.5.3
- app-data-browser-next v0.1.2 -> v0.1.3

## Why?
Bug fix